### PR TITLE
allow GAST 0.3.3 (and greater)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arviz>=0.5.1
-gast==0.3.2
+gast>=0.3.2
 tf-nightly
 tfp-nightly
 pymc3


### PR DESCRIPTION
Current TF-nightly requires 0.3.3